### PR TITLE
feat: Apply performance optimizations and compiler flag enhancements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,4 +30,4 @@ target_link_libraries(pearl-example pearl m)
 add_test(NAME test COMMAND pearl-test)
 
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
-add_compile_options(-O2)
+add_compile_options(-O3 -Wall -Wextra -pedantic)

--- a/src/pearl_layer.c
+++ b/src/pearl_layer.c
@@ -357,6 +357,8 @@ void pearl_layer_update_fully_connected(pearl_layer **child_layer, float learnin
     assert(data->weights->dimension == 2);
     assert(data->weights->size[0] == data->dw->size[0]);
     assert(data->weights->size[1] == data->dw->size[1]);
+
+    #pragma omp parallel for // Add this line
     for (unsigned int i = 0; i < data->weights->size[0]; i++) {
         for (unsigned int j = 0; j < data->weights->size[1]; j++) {
             data->weights->data[ARRAY_IDX_2D(i, j, data->weights->size[1])] -= learning_rate * data->dw->data[ARRAY_IDX_2D(i, j, data->dw->size[1])];

--- a/src/pearl_tensor.c
+++ b/src/pearl_tensor.c
@@ -1,4 +1,5 @@
 #include <pearl_tensor.h>
+#include <string.h> // Add this include
 
 PEARL_API pearl_tensor *pearl_tensor_create(const int num_args, ...)
 {
@@ -39,21 +40,22 @@ PEARL_API pearl_tensor *pearl_tensor_copy(const pearl_tensor *x)
     pearl_tensor *result = calloc(1, sizeof(pearl_tensor));
     result->dimension = x->dimension;
     result->size = calloc(x->dimension, sizeof(unsigned int));
-    int alloc = 1;
+    
+    unsigned int total_elements = 1;
     for (unsigned int i = 0 ; i < x->dimension; i++) {
         result->size[i] = x->size[i];
-        alloc *= x->size[i];
+        total_elements *= x->size[i];
     }
-    result->data = calloc(alloc, sizeof(float));
+    
+    result->data = calloc(total_elements, sizeof(float));
+    if (x->data != NULL && result->data != NULL && total_elements > 0) { // Add checks for safety
+        memcpy(result->data, x->data, total_elements * sizeof(float));
+    } else if (total_elements == 0) {
+        // If total_elements is 0, data might be NULL, which is fine.
+        // If x->data is NULL but total_elements > 0, calloc still provides zeroed memory.
+    }
 
-    unsigned int num_data = 1;
-    for (unsigned int i = 0; i < x->dimension; i++) {
-        num_data *= x->size[i];
-    }
 
-    for (unsigned int i = 0; i < num_data; i++) {
-        result->data[i] = x->data[i];
-    }
     return result;
 }
 


### PR DESCRIPTION
This commit introduces several changes to improve performance and code quality:

1.  **CMakeLists.txt:**
    *   Changed compiler optimization level from -O2 to -O3.
    *   Added -Wall, -Wextra, and -pedantic flags to enable more warnings and enforce stricter C standards.

2.  **Tensor Operations (src/pearl_tensor.c):**
    *   Optimized `pearl_tensor_copy` by:
        *   Consolidating the calculation of total elements.
        *   Using `memcpy` for data copying, which can be more efficient than a manual loop.
        *   Included `<string.h>`.

3.  **Layer Updates (src/pearl_layer.c):**
    *   Parallelized the weight and bias update loop in `pearl_layer_update_fully_connected` using OpenMP (`#pragma omp parallel for`). This can speed up the training process for layers with a significant number of parameters.

These changes should provide a general uplift in performance, particularly during the training phase of neural networks, and improve code robustness through stricter compiler checks.